### PR TITLE
[Feat] Trims down OCI image

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,5 +1,6 @@
 name: sdcore-amf
-base: ubuntu:22.04
+base: bare
+build-base: ubuntu:22.04
 version: '1.3'
 summary: SD-Core AMF
 description: SD-Core AMF
@@ -15,5 +16,7 @@ parts:
     source-commit: a4759dbc2da986bbcec0b8edbd9ddbea27a1944d
     build-snaps:
       - go/1.18/stable
+    stage-packages:
+      - libc6_libs
     organize:
       bin/cmd: bin/amf


### PR DESCRIPTION
# Description

Uses the `bare` base and chiselled libc6. This reduces the container image size to `52MB`, which is:
- 38% smaller than the upstream Docker image (83.6MB)
- 58% smaller than the last version of the ROCK (125MB)

```console
guillaume@thinkpad:~$ docker images | grep -i amf
sdcore-amf                     1.3              c769df5dc791   17 minutes ago      52MB
ghcr.io/canonical/sdcore-amf   1.3              70806e095992   3 weeks ago         125MB
omecproject/5gc-amf            master-a4759db   cc6e58a93c08   5 months ago        83.6MB
```

This will reduce the security surface and decrease deployment time of the AMF.

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.