### PR TITLE
feat: Add arm64 support

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -7,6 +7,7 @@ description: SD-Core AMF
 license: Apache-2.0
 platforms:
   amd64:
+  arm64:
 
 parts:
   amf:


### PR DESCRIPTION
# Description

This PR enables building the AMF rock on arm64. This will currently not be done automatically by the CI however as we do not have access to arm runners. It currently enables manual testing on arm.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.