### PR TITLE
feat: Uses latest AMF commit

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,6 +1,6 @@
 name: sdcore-amf
 base: bare
-build-base: ubuntu:22.04
+build-base: ubuntu@22.04
 version: '1.3'
 summary: SD-Core AMF
 description: SD-Core AMF
@@ -14,9 +14,9 @@ parts:
     plugin: go
     source: https://github.com/omec-project/amf.git
     source-type: git
-    source-commit: a4759dbc2da986bbcec0b8edbd9ddbea27a1944d
+    source-commit: 9cd04c496b032db2861b86f8a95f413cb7e0baf7
     build-snaps:
-      - go/1.18/stable
+      - go/1.21/stable
     stage-packages:
       - libc6_libs
     organize:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -14,7 +14,7 @@ parts:
     plugin: go
     source: https://github.com/omec-project/amf.git
     source-type: git
-    source-commit: 9cd04c496b032db2861b86f8a95f413cb7e0baf7
+    source-commit: ec4f8870d3c8a2d802715c98d95364b787e04958
     build-snaps:
       - go/1.21/stable
     stage-packages:


### PR DESCRIPTION
# Description

This PR uses the latest upstream commit:
- Uses Go 1.21
- Fixes issue where AMF only loaded the NSSF address on startup instead of asking for the new one when needed.

We also bump the build go version to 1.21

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.