### PR TITLE
fix: Fix NudmSDM url after udm crash

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -14,7 +14,7 @@ parts:
     plugin: go
     source: https://github.com/omec-project/amf.git
     source-type: git
-    source-commit: ec4f8870d3c8a2d802715c98d95364b787e04958
+    source-commit: a16a52f97278252499979ef43f9d1b56d86922b8
     build-snaps:
       - go/1.21/stable
     stage-packages:


### PR DESCRIPTION
# Description

Pulls upstream bug fix for NudmSDM url being kept in cache, causing errors after a UDM crash.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.