### PR TITLE
fix: scan on pull_request instead of push

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,10 +1,14 @@
 name: Main
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
+    branches:
+      - main
   schedule:
-    - cron: '0 8 * * 2'
-  workflow_dispatch:
+    - cron: '0 0 * * 0'
 
 jobs:
 


### PR DESCRIPTION
# Description

Only scan on pull_request (and not on push to branches). This is to fix an error affecting dependabot PRs.

## Logs

```
Warning: Workflows triggered by Dependabot on the "push" event run with read-only access. Uploading Code Scanning results requires write access. To use Code Scanning with Dependabot, please ensure you are using the "pull_request" event for this workflow and avoid triggering on the "push" event for Dependabot branches. See https://docs.github.com/en/code-security/secure-coding/configuring-code-scanning#scanning-on-push for more information on how to configure these events.
```

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.