### PR TITLE
fix: revert build-base to 22.04

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,6 +1,6 @@
 name: sdcore-amf
 base: bare
-build-base: ubuntu@24.04
+build-base: ubuntu@22.04
 version: '1.4.1'
 summary: SD-Core AMF
 description: SD-Core AMF


### PR DESCRIPTION
# Description

The 24.04 build base does not work at the moment because of the issue referenced below. Reverting to using 22.04.

## Reference
- https://github.com/canonical/rockcraft/issues/579

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.