### PR TITLE
fix: Update skopeo in doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,8 @@
 ## Build and deploy
 
 ```bash
+sudo snap install rockcraft --classic --edge
 rockcraft pack -v
-sudo skopeo --insecure-policy copy oci-archive:sdcore-amf_1.4.1_amd64.rock docker-daemon:sdcore-amf:1.4.1
-docker run sdcore-amf:1.4.1
+sudo rockcraft.skopeo --insecure-policy copy oci-archive:sdcore-amf_1.4.2_amd64.rock docker-daemon:sdcore-amf:1.4.2
+docker run sdcore-amf:1.4.2
 ```


### PR DESCRIPTION


# Description

skopeo from apt and snap store no longer works with docker > 1.24. The version of skopeo from rockcraft is recent enough to use as a replacement

## Checklist

- [X] I have performed a self-review of my own code.
- [X] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.