### PR TITLE
fix: Trigger actions on PR merges and release branches

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,6 +5,11 @@ on:
     types: [edited, opened, reopened, synchronize]
     branches:
       - main
+      - v**
+  push:
+    branches:
+      - main
+      - v**
   schedule:
     - cron: '0 0 * * 0'
 


### PR DESCRIPTION
# Description

The previous PR (#45) removing the trigger on `push` had the unintended effect of disabling CI when merging a PR. This PR re-enables the `push` event, but limits it only to the `main` and release branches.

Similarly, it also triggers for PRs targeting release branches.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.