### PR TITLE
chore: workflows trigger only on PR events, and not on push

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,7 +5,8 @@ on:
     branches:
       - v1.5.1
   push:
-
+    branches:
+      - v1.5.1
 jobs:
 
   build-rock:


### PR DESCRIPTION
# Description

This change makes the CI trigger only on PR events, and not on push. This will prevent duplicate runs of CI jobs. It will also prevent the scan-rock failing when run on push.

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.