### PR TITLE
chore: bump workload to v1.6.4

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,6 @@
 ```bash
 sudo snap install rockcraft --classic --edge
 rockcraft pack -v
-sudo rockcraft.skopeo --insecure-policy copy oci-archive:sdcore-amf_1.4.2_amd64.rock docker-daemon:sdcore-amf:1.4.2
-docker run sdcore-amf:1.4.2
+sudo rockcraft.skopeo --insecure-policy copy oci-archive:sdcore-amf_1.6.4_amd64.rock docker-daemon:sdcore-amf:1.6.4
+docker run sdcore-amf:1.6.4
 ```

--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ Container image for SD-Core AMF.
 ## Usage
 
 ```console
-docker pull ghcr.io/canonical/sdcore-amf:1.6.0
-docker run -it ghcr.io/canonical/sdcore-amf:1.6.0
+docker pull ghcr.io/canonical/sdcore-amf:1.6.4
+docker run -it ghcr.io/canonical/sdcore-amf:1.6.4
 ```

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: sdcore-amf
 base: bare
 build-base: ubuntu@24.04
-version: '1.6.1'
+version: '1.6.4'
 summary: SD-Core AMF
 description: SD-Core AMF
 license: Apache-2.0
@@ -16,7 +16,7 @@ parts:
     source-type: git
     source-tag: v${CRAFT_PROJECT_VERSION}
     build-snaps:
-      - go/1.21/stable
+      - go/1.23/stable
     stage-packages:
       - libc6_libs
       - base-files_lib


### PR DESCRIPTION
# Description

Bump AMF workload to the latest upstream release v1.6.4. We also bump the go version to the same as used in the upstream project: 1.23.

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.